### PR TITLE
Restores .NET Framework 4.8 compatibility, and forces Windows 7 to use…

### DIFF
--- a/gg-downloader/Program.cs
+++ b/gg-downloader/Program.cs
@@ -30,6 +30,19 @@ namespace gg_downloader
             // Initialize the settings Provider
             _settings = new INISettingsProvider(GOG_GAMES_CDN_ROOT);
 
+            // For Windows 7, we specifically need to tell the ServicePointManager to use 
+            // TLS1.2. As we can only be running the .NET Framework version on Windows 7,
+            // we'll conditionally compile this out by checking for .NET 5.0. OS Version 6.1
+            // equates to Windows 7 _or_ Windows Server 2008, and hey, this fix is probably
+            // needed for it too.
+#if !NET
+            if (System.Environment.OSVersion.Version.Major == 6 &&
+                System.Environment.OSVersion.Version.Minor == 1)
+            {
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            }
+#endif
+
             RootCommand rootCommand = new RootCommand("Download files from GOG Games CDN.");
 
             Command donateCommand = new Command("donate", "open the GOG Games Store link for CDN access");

--- a/gg-downloader/gg-downloader.csproj
+++ b/gg-downloader/gg-downloader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net7.0</TargetFrameworks>
+		<TargetFrameworks>net48;net7.0</TargetFrameworks>
 		<OutputType>Exe</OutputType>
 		<RootNamespace>gg_downloader</RootNamespace>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
… TLS12 (which is doesn't do by default)