### PR TITLE
Squashed commit of the following:

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ In addition to the options above, the download command has several additional op
 
 `--game` Download the game files [default: True]
 
+`-t` or `--threads <threads>` how many threads to use for downloading (max: 4) [default: 4]
+
 **Examples**
 
 Authenticate against the CDN and set the username and password for the first time: `./gg-downloader.exe auth`

--- a/gg-downloader/Models/RangeHeaders.cs
+++ b/gg-downloader/Models/RangeHeaders.cs
@@ -1,0 +1,10 @@
+using System.Net.Http.Headers;
+
+namespace gg_downloader.Models
+{
+    internal class RangeHeaders
+    {
+        public long? ContentLength { get; set; }
+        public HttpHeaderValueCollection<string> AcceptRanges { get; set; }
+    }
+}

--- a/gg-downloader/Program.cs
+++ b/gg-downloader/Program.cs
@@ -43,6 +43,7 @@ namespace gg_downloader
                 ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             }
 #endif
+            ServicePointManager.DefaultConnectionLimit = 5;
 
             RootCommand rootCommand = new RootCommand("Download files from GOG Games CDN.");
 
@@ -109,6 +110,8 @@ namespace gg_downloader
             Option<bool> goodiesOption = new Option<bool>("--goodies", () => true, "download the goodies");
             Option<bool> patchesOption = new Option<bool>("--patches", () => false, "download the patches");
             Option<bool> gameOption = new Option<bool>("--game", () => true, "download the game files");
+            Option<int> threadOption = new Option<int>("--threads", () => 4, "how many threads to use for downloading (max: 4)");
+            threadOption.AddAlias("-t");
             Command downloadCommand = new Command("download", "download a game from the GOG Games CDN");
             downloadCommand.AddOption(userOption);
             downloadCommand.AddAlias("d");
@@ -119,9 +122,10 @@ namespace gg_downloader
             downloadCommand.AddOption(goodiesOption);
             downloadCommand.AddOption(patchesOption);
             downloadCommand.AddOption(gameOption);
+            downloadCommand.AddOption(threadOption);
             Argument<string> urlOrSlug = new Argument<string>("slug-or-url", "slug or URL to download");
             downloadCommand.AddArgument(urlOrSlug);
-          
+
             downloadCommand.SetHandler(async (context) =>
             {
                 await DownloadGame(
@@ -133,7 +137,8 @@ namespace gg_downloader
                     context.ParseResult.GetValueForOption(unsafeOption),
                     context.ParseResult.GetValueForOption(goodiesOption),
                     context.ParseResult.GetValueForOption(patchesOption),
-                    context.ParseResult.GetValueForOption(gameOption)
+                    context.ParseResult.GetValueForOption(gameOption),
+                    context.ParseResult.GetValueForOption(threadOption)
                     );
             });
 
@@ -143,7 +148,7 @@ namespace gg_downloader
         }
 
         private static async Task DownloadGame(string slugOrUrl, string username, string password,
-            string downloadRoot, bool noDir, bool noVerify, bool goodies, bool patches, bool game)
+            string downloadRoot, bool noDir, bool noVerify, bool goodies, bool patches, bool game, int threads)
         {
 
             // okay, here we go. First thing we need to sort out is whether we were given a URL 
@@ -165,10 +170,16 @@ namespace gg_downloader
             Dictionary<string, string> sfvDictionary = new Dictionary<string, string>();
             if (!noVerify)
             {
-                string checkSums =
-                    await (await HttpRequest.Get(new Uri(downloadRoot + "/sfv/" + slug + ".sfv"), username, password))
-                        .Content.ReadAsStringAsync();
-                foreach (string line in checkSums.Split(new [] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
+                var sfvResponse = await HttpRequest.Get(new Uri(downloadRoot + "/sfv/" + slug + ".sfv"), username, password);
+                if (!sfvResponse.IsSuccessStatusCode)
+                {
+                    var errorMessage = await sfvResponse.Content.ReadAsStringAsync();
+                    Console.WriteLine($"Error executing request: {uri.AbsoluteUri}: {errorMessage} (HTTP {sfvResponse.StatusCode})");
+                    return;
+                }
+
+                string checkSums = await sfvResponse.Content.ReadAsStringAsync();
+                foreach (string line in checkSums.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None))
                 {
                     try
                     {
@@ -199,40 +210,35 @@ namespace gg_downloader
             if (!noDir)
             {
                 Directory.CreateDirectory(slug);
-            } 
+            }
 
             foreach (FileToDownloadInfo file in files)
             {
-                string url = downloadRoot + "/" + 
-                    (file.Type == FileToDownloadInfo.FileType.Patch ? "patches/" : "downloads/" + slug) + 
-                    "/"+ file.FileName;
+                string url = downloadRoot + "/" +
+                    (file.Type == FileToDownloadInfo.FileType.Patch ? "patches/" : "downloads/" + slug) +
+                    "/" + file.FileName;
                 string filename = (noDir ? "./" : slug + "/") + file.FileName;
-                
+
                 Console.WriteLine($"Downloading {url}");
                 uint crc32CheckSum;
 
-                using (var client = new HttpClientDownloadWithProgress(url, filename, username, password))
+                using (var manager = new DownloadManager(url, filename, username, password, sfvDictionary, threads))
                 {
-                    client.ProgressChanged += (totalFileSize, totalBytesDownloaded, progressPercentage) => {
-                        Console.Write($"\r{progressPercentage}% ({totalBytesDownloaded}/{totalFileSize})");
-                    };
-
-                    crc32CheckSum = await client.StartDownload();
+                    crc32CheckSum = await manager.StartDownload();
                 }
-                Console.WriteLine($"\r{file.FileName} downloaded.");
 
                 if (noVerify) continue;
 
                 // check the file against the sfv dictionary.
                 if (crc32CheckSum.ToString("X8").ToLower() != sfvDictionary[file.FileName])
                 {
-                    Console.WriteLine($"\r{file.FileName} failed SFV validation.");
+                    Console.WriteLine($"{file.FileName} failed SFV validation after download.");
                     Console.WriteLine("Halting...");
                     return;
                 }
                 else
                 {
-                    Console.WriteLine($"\r{file.FileName} passed SFV validation.");
+                    Console.WriteLine($"{file.FileName} passed SFV validation.");
                 }
             }
 
@@ -240,7 +246,7 @@ namespace gg_downloader
 
         private static string ConvertUriToSlug(Uri uri)
         {
-            return uri.ToString().Substring(uri.ToString().LastIndexOf('/')+1);
+            return uri.ToString().Substring(uri.ToString().LastIndexOf('/') + 1);
         }
 
         private static List<string> ExtractFilesFromPage(Regex fileBlockRegex, string pageContent)
@@ -267,7 +273,7 @@ namespace gg_downloader
             List<FileToDownloadInfo> results = new List<FileToDownloadInfo>();
             foreach (string s in filesInBlock)
             {
-                results.Add(new FileToDownloadInfo {  FileName = s, Type = FileToDownloadInfo.FileType.Game });
+                results.Add(new FileToDownloadInfo { FileName = s, Type = FileToDownloadInfo.FileType.Game });
             }
             return results;
         }
@@ -404,8 +410,16 @@ namespace gg_downloader
                 Console.WriteLine("GG-Downloader-Win: auth: Incorrect username/password");
                 return;
             }
+            else if (result.IsSuccessStatusCode)
+            {
+                Console.WriteLine("GG-Downloader-Win: auth: Successful log-in");
+            }
+            else
+            {
+                Console.WriteLine($"Error {(int)result.StatusCode}: {result.ReasonPhrase}");
+            }
 
-            Console.WriteLine("GG-Downloader-Win: auth: Successful log-in");
+
         }
 
         private static void SetCDNRoot(string cdnRoot)

--- a/gg-downloader/Services/DownloadManager.cs
+++ b/gg-downloader/Services/DownloadManager.cs
@@ -1,0 +1,259 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Force.Crc32;
+using gg_downloader.Models;
+using System.Linq;
+using Polly;
+using Polly.Retry;
+using System.Threading;
+
+namespace gg_downloader.Services
+{
+
+    public class DownloadManager : IDisposable
+    {
+        private readonly string _downloadUrl;
+        private readonly string _destinationFilePath;
+        private readonly string _username;
+        private readonly string _password;
+        private const long minChunkSize = 100 * 1024 * 1024;
+        private const int _maxThreads = 4;
+        private readonly int _threads;
+        private readonly DownloadProgressTracker _progressManager;
+        private HttpClient _httpClient;
+        private Dictionary<int, long> _downloadedBytes;
+        private DateTime _startTime;
+        private DateTime _endTime;
+        private readonly Dictionary<string, string> _sfvDictionary;
+        private readonly object objectLock = new object();
+        private readonly AsyncRetryPolicy<HttpResponseMessage> _retryPolicy;
+
+        public DownloadManager(string downloadUrl, string destinationFilePath, string username, string password, Dictionary<string, string> sfvDictionary, int threads)
+        {
+            _downloadUrl = downloadUrl;
+            _destinationFilePath = destinationFilePath;
+            _username = username;
+            _password = password;
+            _downloadedBytes = new Dictionary<int, long>();
+            _sfvDictionary = sfvDictionary;
+            _threads = threads > _maxThreads ? _maxThreads : threads;
+
+            _progressManager = new DownloadProgressTracker();
+
+            _httpClient = new HttpClient();
+            _httpClient.Timeout = TimeSpan.FromMinutes(5);
+
+
+            _retryPolicy = Policy.HandleResult<HttpResponseMessage>(res => !res.IsSuccessStatusCode)
+                     .Or<Exception>()
+                     .RetryAsync(10, onRetry: (delegateResult, retryCount) =>
+                     {
+                         Console.Out.WriteLine($"Error: {delegateResult?.Exception?.Message ?? "No exception"}, retrying: {retryCount}/10");
+                         Thread.Sleep(500);
+                     });
+        }
+
+        private HttpClient CleanHttpClient
+        {
+            get
+            {
+                _httpClient.DefaultRequestHeaders.Clear();
+
+                byte[] byteArray = Encoding.ASCII.GetBytes($"{_username}:{_password}");
+                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+                _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("GOG-Downloader-Win/1.0");
+
+                return _httpClient;
+            }
+        }
+
+        public async Task<uint> StartDownload()
+        {
+            var range = await getFileSize();
+
+            uint checksum = await CheckIfDownloadAlreadyDone();
+            if (checksum > 0) return checksum;
+
+            _progressManager.Reset();
+            _progressManager.TotalDownloadSize = range.ContentLength;
+
+            if (range.AcceptRanges != null && range.AcceptRanges.Contains("bytes") && range.ContentLength.HasValue)
+                checksum = await MultiThreadDownload(range.ContentLength.Value);
+            else
+                checksum = await SingleThreadDownload(range.ContentLength);
+
+            _progressManager.Stop();
+
+            PrintTotalDownloadTime(_endTime - _startTime, range.ContentLength);
+            return checksum;
+        }
+
+        private async Task<uint> CheckIfDownloadAlreadyDone()
+        {
+            string filename = Path.GetFileName(_destinationFilePath);
+
+            if (_sfvDictionary != null && !string.IsNullOrEmpty(filename) && File.Exists(_destinationFilePath) && _sfvDictionary.ContainsKey(filename))
+            {
+                Console.WriteLine($"{filename} found in destination path.");
+
+                var crc32CheckSum = await Crc32FromFile();
+
+                if (crc32CheckSum.ToString("X8").ToLower() == _sfvDictionary[filename])
+                {
+                    return crc32CheckSum;
+                }
+                Console.WriteLine($"{filename} failed SFV validation. Will download again.");
+            }
+
+            return 0;
+        }
+
+        private void PrintTotalDownloadTime(TimeSpan downloadTime, long? contentLength)
+        {
+            var filename = Path.GetFileName(_destinationFilePath);
+            var speed = (contentLength / downloadTime.TotalSeconds) / (1024 * 1024);
+            var filesize = (double)contentLength / (1024 * 1024);
+            Console.WriteLine($"\rDownloaded {filename}. {Math.Round(filesize, 2)} MiB in {downloadTime.TotalSeconds} seconds ({Math.Round(speed.Value, 2)} MB/s).");
+        }
+
+        private async Task<uint> SingleThreadDownload(long? contentLength)
+        {
+
+            var downloadTask = new HttpClientDownloadWithProgress(_downloadUrl, _destinationFilePath, CleanHttpClient, 0, contentLength, contentLength, 0);
+            downloadTask.DownloadedBytesChanged += UpdateDownloadedBytes;
+
+            _startTime = DateTime.Now;
+            var checkSum = await downloadTask.ThreadedDownload();
+            _endTime = DateTime.Now;
+
+            return checkSum;
+        }
+
+        private async Task<uint> MultiThreadDownload(long contentLength)
+        {
+            var chunks = (contentLength / minChunkSize);
+            if (chunks > _threads) chunks = _threads;
+
+            if (chunks < 2) return await SingleThreadDownload(contentLength);
+
+            var chunkSize = contentLength / chunks;
+            var downloadTasks = new List<HttpClientDownloadWithProgress>();
+
+            for (int i = 0; i < chunks; i++)
+            {
+                var startByte = chunkSize * i;
+                var endByte = (chunkSize * (i + 1)) - 1;
+                if (i == chunks - 1) endByte = contentLength; //Sets the last byte of last chunk
+
+                var task = new HttpClientDownloadWithProgress(_downloadUrl, _destinationFilePath, CleanHttpClient, startByte, endByte, contentLength, i);
+                task.DownloadedBytesChanged += UpdateDownloadedBytes;
+
+                downloadTasks.Add(task);
+            }
+
+            _startTime = DateTime.Now;
+
+            //start chunks of download, save to separate files
+            var result = await Task.WhenAll(downloadTasks.Select(async x => await x.ThreadedDownload()));
+
+            _endTime = DateTime.Now;
+            _progressManager.Stop();
+
+            //return complete checksum for all parts 
+            var checkSumFromFile = await Crc32FromFile();
+
+            return checkSumFromFile;
+        }
+
+        private void UpdateDownloadedBytes(int chunkNumber, long totalBytesRead)
+        {
+            long totalBytes = 0;
+
+            _downloadedBytes[chunkNumber] = totalBytesRead;
+            totalBytes = _downloadedBytes.Sum(x => x.Value);
+
+            if (totalBytes > 0) _progressManager.Start();
+
+            _progressManager.CurrentBytesRead = totalBytes;
+        }
+
+        private async Task<RangeHeaders> getFileSize()
+        {
+            var client = CleanHttpClient;
+
+            var message = new HttpRequestMessage(HttpMethod.Head, _downloadUrl);
+
+            var response = await _retryPolicy.ExecuteAsync(async () =>
+                        await client.SendAsync(message, HttpCompletionOption.ResponseHeadersRead)
+            );
+
+            var headers = new RangeHeaders()
+            {
+                ContentLength = response.Content.Headers.ContentLength,
+                AcceptRanges = response.Headers.AcceptRanges
+            };
+
+            return headers;
+        }
+
+        private async Task<uint> Crc32FromFile(bool reportSpeed = true)
+        {
+            int bufferSize = 65536;
+            var totalBytesRead = 0L;
+            var buffer = new byte[bufferSize];
+            var isMoreToRead = true;
+            uint checksum = 0;
+            double lastPercent = -1;
+
+            if (!File.Exists(_destinationFilePath)) return 0;
+
+            using (var fileStream = new FileStream(_destinationFilePath, FileMode.Open, FileAccess.Read, FileShare.None, bufferSize, true))
+            {
+                Console.Write("\n");
+                do
+                {
+                    var bytesRead = await fileStream.ReadAsync(buffer, 0, buffer.Length);
+
+                    // calculate the CRC32 on what we downloaded.
+                    checksum = Crc32Algorithm.Append(checksum, buffer, 0, bytesRead);
+
+                    if (bytesRead == 0)
+                    {
+                        isMoreToRead = false;
+                        continue;
+                    }
+
+                    totalBytesRead += bytesRead;
+
+                    if (reportSpeed)
+                    {
+                        var percent = Math.Round((double)totalBytesRead / fileStream.Length * 100, 0);
+                        if (percent != lastPercent)
+                        {
+                            lastPercent = percent;
+                            var percentString = percent.ToString().PadLeft(3, ' ');
+                            Console.Write($"\rCalculating CRC32 {percentString}% ...");
+                        }
+                    }
+                }
+                while (isMoreToRead);
+            }
+
+            Console.WriteLine("complete.");
+
+            return checksum;
+        }
+
+
+        public void Dispose()
+        {
+            _progressManager?.Dispose();
+            _httpClient?.Dispose();
+        }
+    }
+}

--- a/gg-downloader/Services/DownloadProgressTracker.cs
+++ b/gg-downloader/Services/DownloadProgressTracker.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using Timer = System.Timers.Timer;
+using System.Collections.Generic;
+
+
+namespace gg_downloader.Services
+{
+    internal class DownloadProgressTracker : IDisposable
+    {
+        // Private properties & class variables
+        private readonly Timer _downloadTimer;
+        private List<long> _totalBytesRead;
+        private int _maxDataPoints;
+        private const double _timerInterval = 200;
+        private const int _speedMeasurementInterval = 10000; //10 seconds
+        private string currentText = string.Empty;
+
+        //public properties and delegates
+        public long? TotalDownloadSize { get; set; }
+        public long CurrentBytesRead { get; set; }
+
+        public DownloadProgressTracker()
+        {
+            _downloadTimer = new Timer(_timerInterval);
+            _downloadTimer.Elapsed += updateDownloadStatus;
+            _maxDataPoints = _speedMeasurementInterval / Convert.ToInt32(_timerInterval);
+            _totalBytesRead = new List<long>();
+        }
+
+        public void Start()
+        {
+            _downloadTimer.Enabled = true;
+        }
+
+        public void Stop()
+        {
+            _downloadTimer.Stop();
+            TriggerProgressChanged();
+            Reset();
+        }
+
+        public void Reset()
+        {
+            TotalDownloadSize = 0;
+            CurrentBytesRead = 0;
+            _totalBytesRead = new List<long>();
+        }
+
+        private void updateDownloadStatus(object sender, System.Timers.ElapsedEventArgs e)
+        {
+            TriggerProgressChanged();
+        }
+
+        private double calculateCurrentSpeed()
+        {
+            double speedSums = 0;
+
+            for (int i = 0; i < _totalBytesRead.Count - 1; i++)
+            {
+                speedSums += (_totalBytesRead[i + 1] - _totalBytesRead[i]);
+            }
+
+            var meanSpeed = speedSums / _totalBytesRead.Count;
+
+            return meanSpeed * (1000 / _timerInterval);
+        }
+
+        private void TriggerProgressChanged()
+        {
+
+            _totalBytesRead.Add(CurrentBytesRead);
+            if (_totalBytesRead.Count > _maxDataPoints) _totalBytesRead.RemoveAt(0);
+
+            double? dblDownloadSize = TotalDownloadSize;
+            double dblBytesRead = CurrentBytesRead;
+            double? progressPercentage = null;
+            double currentSpeed = 0;
+
+            //Calculate percentage
+            if (dblDownloadSize.HasValue)
+                progressPercentage = (double)dblBytesRead / dblDownloadSize.Value;
+
+            //Calculate Speed
+            currentSpeed = calculateCurrentSpeed();
+            string speed = "0 bps";
+
+            long gb = 1024 * 1024 * 1024;
+            long mb = 1024 * 1024;
+            long kb = 1024;
+            var unit = "bytes";
+
+            if (dblBytesRead > (gb * 0.85))
+            {
+                dblBytesRead = dblBytesRead / gb;
+                dblDownloadSize = dblDownloadSize / gb;
+                unit = "GiB";
+            }
+            else if (dblBytesRead > (mb * 0.85))
+            {
+                dblBytesRead = dblBytesRead / mb;
+                dblDownloadSize = dblDownloadSize / mb;
+                unit = "MiB";
+            }
+            else if (dblBytesRead > (kb * 0.85))
+            {
+                dblBytesRead = dblBytesRead / kb;
+                dblDownloadSize = dblDownloadSize / kb;
+                unit = "Kib";
+            }
+
+            if (currentSpeed > gb) speed = $"{Math.Round(currentSpeed / gb, 2)} GB/s";
+            else if (currentSpeed > mb) speed = $"{Math.Round(currentSpeed / mb, 2)} MB/s";
+            else if (currentSpeed > kb) speed = $"{Math.Round(currentSpeed / kb, 2)} KB/s";
+            else speed = $"{currentSpeed} bps";
+
+            ProgressChanged(Math.Round(dblDownloadSize.Value, 2), Math.Round(dblBytesRead, 2), progressPercentage, unit, speed);
+        }
+
+        private void ProgressChanged(double? totalFileSize, double totalBytesDownloaded, double? progressPercentage, string unit, string speed)
+        {
+            var text = $"\r{(progressPercentage.Value * 100).ToString("F2")}% ({totalBytesDownloaded}/{totalFileSize} {unit}) {speed}      ";
+            Console.Write(text);
+        }
+
+        public void Dispose()
+        {
+            _downloadTimer.Dispose();
+        }
+    }
+}

--- a/gg-downloader/Services/HttpClientDownloadWithProgress.cs
+++ b/gg-downloader/Services/HttpClientDownloadWithProgress.cs
@@ -2,128 +2,150 @@
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Force.Crc32;
 using Polly;
 using Polly.Retry;
+using Polly.Timeout;
 
 namespace gg_downloader.Services
 {
-    public class HttpClientDownloadWithProgress : IDisposable
+    public class HttpClientDownloadWithProgress
     {
         private readonly string _downloadUrl;
         private readonly string _destinationFilePath;
-        private readonly string _username;
-        private readonly string _password;
         private readonly AsyncRetryPolicy<uint> _retryPolicy;
-
+        private readonly AsyncTimeoutPolicy _timeoutPolicy;
         private HttpClient _httpClient;
+        private readonly long? _contentLength;
+        private readonly long _startByte;
+        private readonly long? _endByte;
+        private long _totalBytesRead;
+        private uint _checksum;
 
-        public delegate void ProgressChangedHandler(long? totalFileSize, long totalBytesDownloaded, double? progressPercentage);
 
-        public event ProgressChangedHandler ProgressChanged;
+        public readonly int ChunkNumber;
+        public string FilePath { get { return _destinationFilePath; } }
+        public long StartByte { get { return _startByte; } }
+        public long? EndByte { get { return _endByte; } }
+        public uint Checksum { get { return _checksum; } }
 
-        public HttpClientDownloadWithProgress(string downloadUrl, string destinationFilePath, string username, string password)
+        public delegate void DownloadedBytesChangedHandler(int chunkNumber, long totalBytesDownloaded);
+        public event DownloadedBytesChangedHandler DownloadedBytesChanged;
+
+        public HttpClientDownloadWithProgress(string downloadUrl, string destinationFilePath, HttpClient httpClient, long startByte, long? endByte, long? contentLength, int chunkNumber)
         {
             _downloadUrl = downloadUrl;
             _destinationFilePath = destinationFilePath;
-            _username = username;
-            _password = password;
+            _httpClient = httpClient;
+            _startByte = startByte;
+            _endByte = endByte;
+            _contentLength = contentLength;
+            ChunkNumber = chunkNumber;
+
             _retryPolicy = Policy.HandleResult<uint>(res => res < 0)
                                  .Or<Exception>()
                                  .RetryAsync(10, onRetry: (delegateResult, retryCount) =>
                                  {
-                                     Console.Out.WriteLine($"Error: {delegateResult?.Exception?.Message ?? "No exception"}");
-                                     Console.Out.WriteLine($"Retrying: {retryCount}");
+                                     if (delegateResult.Exception.GetType() != typeof(TimeoutRejectedException))
+                                     {
+                                        Console.Out.WriteLine($" - Error: {delegateResult?.Exception?.Message ?? "No exception"}, retrying: {retryCount}/10");
+                                     }
+                                     else
+                                     {
+                                         Console.Out.WriteLine($" - Download thread {ChunkNumber} stalled, retrying: {retryCount}/10");
+                                     }
+
                                      Thread.Sleep(500);
                                  });
+            _timeoutPolicy = Policy.TimeoutAsync(10);
         }
 
-        public async Task<uint> StartDownload()
+        public async Task<uint> ThreadedDownload()
         {
-            _httpClient = new HttpClient { Timeout = TimeSpan.FromDays(1) };
-            byte[] byteArray = Encoding.ASCII.GetBytes($"{_username}:{_password}");
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
-            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("GOG-Downloader-Win/1.0");
-
+            _totalBytesRead = 0;
+            _checksum = 0;
 
             var checksum = await _retryPolicy.ExecuteAsync(async () =>
             {
-                using (var response = await _httpClient.GetAsync(_downloadUrl, HttpCompletionOption.ResponseHeadersRead))
-                    return await DownloadFileFromHttpResponseMessageWithCrc32(response);
+                if (_endByte.HasValue) _httpClient.DefaultRequestHeaders.Range = new RangeHeaderValue(_startByte + _totalBytesRead, _endByte);
+                //Console.WriteLine($"startByte: {_startByte}, TotalBytesRead: {_totalBytesRead}, EndByte: {_endByte}");
+
+                using (var cts = new CancellationTokenSource())
+                using (var response = await _httpClient.GetAsync(_downloadUrl, HttpCompletionOption.ResponseHeadersRead, cts.Token))
+                    return await DownloadFileFromHttpResponseMessageWithCrc32(_destinationFilePath, response, cts.Token);
             });
 
             return checksum;
-
         }
 
-        private async Task<uint> DownloadFileFromHttpResponseMessageWithCrc32(HttpResponseMessage response)
+        private async Task<uint> DownloadFileFromHttpResponseMessageWithCrc32(string filePath, HttpResponseMessage response, CancellationToken cts)
         {
             response.EnsureSuccessStatusCode();
 
             var totalBytes = response.Content.Headers.ContentLength;
+            var contentRange = response.Content.Headers.ContentRange;
+
+            if (contentRange == null)
+            {
+                Console.WriteLine("Range header null");
+            }
 
             using (var contentStream = await response.Content.ReadAsStreamAsync())
-                return await ProcessContentStream(totalBytes, contentStream);
+                return await ProcessContentStream(filePath, contentStream, contentRange, cts);
         }
 
-        private async Task<uint> ProcessContentStream(long? totalDownloadSize, Stream contentStream)
+        private async Task<uint> ProcessContentStream(string filePath, Stream contentStream, ContentRangeHeaderValue rangeHeaderValue, CancellationToken cts)
         {
-            var totalBytesRead = 0L;
-            var readCount = 0L;
-            var buffer = new byte[8192];
+            int bufferSize = 16384;
+            var fileWritePosition = rangeHeaderValue?.From ?? 0;
+            var buffer = new byte[bufferSize];
             var isMoreToRead = true;
-            uint? checksum = null;
+            long readCount = 0;
 
-            using (var fileStream = new FileStream(_destinationFilePath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
+            using (var fileStream = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite, bufferSize, true))
+            //using (var fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, 8192, true))
             {
+                fileStream.Seek(fileWritePosition, SeekOrigin.Begin);
+
                 do
                 {
-                    var bytesRead = await contentStream.ReadAsync(buffer, 0, buffer.Length);
-
-                    // calculate the CRC32 on what we downloaded.
-                    checksum = !checksum.HasValue
-                        ? Crc32Algorithm.Compute(buffer, 0, bytesRead)
-                        : Crc32Algorithm.Append(checksum.Value, buffer, 0, bytesRead);
-
-                    if (bytesRead == 0)
+                    using (cts.Register(() => contentStream.Close()))
                     {
-                        isMoreToRead = false;
-                        TriggerProgressChanged(totalDownloadSize, totalBytesRead);
-                        continue;
+                        await _timeoutPolicy.ExecuteAsync(async token =>
+                        {
+                            var bytesRead = await contentStream.ReadAsync(buffer, 0, buffer.Length, token);
+
+                            //calculate the CRC32 on what we downloaded.s
+                            _checksum = Crc32Algorithm.Append(_checksum, buffer, 0, bytesRead);
+
+                            if (bytesRead == 0)
+                            {
+                                isMoreToRead = false;
+                                TriggerProgressChanged(_totalBytesRead);
+                            }
+
+                            await fileStream.WriteAsync(buffer, 0, bytesRead);
+
+                            _totalBytesRead += bytesRead;
+                            readCount++;
+                            if (readCount % 100 == 0)
+                                TriggerProgressChanged(_totalBytesRead);
+
+                        }, cts);
                     }
-
-                    await fileStream.WriteAsync(buffer, 0, bytesRead);
-
-                    totalBytesRead += bytesRead;
-                    readCount += 1;
-
-                    if (readCount % 100 == 0)
-                        TriggerProgressChanged(totalDownloadSize, totalBytesRead);
                 }
                 while (isMoreToRead);
             }
 
-            return checksum.Value;
+            return _checksum;
         }
 
-        private void TriggerProgressChanged(long? totalDownloadSize, long totalBytesRead)
+        private void TriggerProgressChanged(long totalBytesRead)
         {
-            if (ProgressChanged == null)
-                return;
-
-            double? progressPercentage = null;
-            if (totalDownloadSize.HasValue)
-                progressPercentage = Math.Round((double)totalBytesRead / totalDownloadSize.Value * 100, 2);
-
-            ProgressChanged(totalDownloadSize, totalBytesRead, progressPercentage);
-        }
-
-        public void Dispose()
-        {
-            _httpClient?.Dispose();
+            if (DownloadedBytesChanged != null)
+                DownloadedBytesChanged(ChunkNumber, totalBytesRead);
         }
     }
 }

--- a/gg-downloader/Services/HttpRequestProvider.cs
+++ b/gg-downloader/Services/HttpRequestProvider.cs
@@ -2,20 +2,39 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Polly;
+using Polly.Retry;
 
 namespace gg_downloader.Services
 {
     internal class HttpRequest
     {
 
-        static readonly HttpClient client = new HttpClient();
+        static readonly HttpClient client;
+        static readonly AsyncRetryPolicy<HttpResponseMessage> _retryPolicy;
 
-        public static async Task< HttpResponseMessage> Get(Uri uri)
+        static HttpRequest()
+        {
+            client = new HttpClient();
+            _retryPolicy = Policy.HandleResult<HttpResponseMessage>(res => !res.IsSuccessStatusCode)
+                     .Or<Exception>()
+                     .RetryAsync(10, onRetry: (delegateResult, retryCount) =>
+                            {
+                                Console.Out.WriteLine($"Error: {delegateResult?.Exception?.Message ?? "No exception"}, retrying: {retryCount}/10");
+                                Thread.Sleep(500);
+                            });
+        }
+
+        public static async Task<HttpResponseMessage> Get(Uri uri)
         {
             client.DefaultRequestHeaders.UserAgent.ParseAdd("GOG-Downloader-Win/1.0");
+            
+            HttpResponseMessage response = await _retryPolicy.ExecuteAsync(async () =>
+                await client.GetAsync(uri)
+            );
 
-            HttpResponseMessage response = await client.GetAsync(uri);
             return response;
         }
 
@@ -26,7 +45,10 @@ namespace gg_downloader.Services
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
             client.DefaultRequestHeaders.UserAgent.ParseAdd("GOG-Downloader-Win/1.0");
 
-            HttpResponseMessage response = await client.GetAsync(uri);
+            HttpResponseMessage response = await _retryPolicy.ExecuteAsync(async () =>
+                await client.GetAsync(uri)
+            );
+
             return response;
         }
 


### PR DESCRIPTION
## Changes
- Added threaded downloading option (default = max = 4), saving to same file.

- Mimimum size for download chunk if 100MiB, so smaller files will use less threads, regardless of thread setting.

- Connection restarts from last saved byte on idle timeout.
- Checks if file exists before download, and if so, verifies checksum against sfv.
- Error handling on auth, and sfv download.
- Added speed on download progress, and size in human readable format.
- When downloaded is threaded, it was necessary to checksum the file after the complete download. However, it should be possible to calculate the CRC32 for the whole file from the checksums of the parts.
- Tried to make error messages during download not fill the screen, but still be usable as a log.

## This PR is a squash of the following commits:

commit 32a3e79e16aba307507a35647bf2d80e0441e4e7
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Tue Jan 24 17:07:32 2023 -0300

    Updated readme.md

commit 962f88c00845379cae7b7a560307b2222d79bd7b
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Tue Jan 24 17:03:52 2023 -0300

    Remove unused method

commit 38d6168a2603c0e7c8391c2c0cf6436d4b5bb3be
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Tue Jan 24 16:55:35 2023 -0300

    Increased timeout for httpclient, formatted error message

commit c62c297ba1f39cfa1805517cdae9c448dd21dd0a
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Tue Jan 24 16:54:19 2023 -0300

    Added retry policy for HttpRequestProvider

commit c6a88691c5d5072b990736a3f1a2a42bf7d2b956
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Mon Jan 23 22:09:04 2023 -0300

    Increased chunk size back to 100MiB

commit 9f18a92863693905d534913c73ffca056f9762d1
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Mon Jan 23 22:02:46 2023 -0300

    Added retry policy to call to get size

commit 94971be615e4df860b53dde8aa69e2425c262020
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Mon Jan 23 20:10:33 2023 -0300

    Removed comments and unused methods

commit 1154917a108e0f8db4eca8be5da91142f4ccf346
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Mon Jan 23 19:37:11 2023 -0300

    WIP - trying to make partial checksums work

commit cfe287c738c98b485eaa8ce4d2007bfa0af7af7e
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Mon Jan 23 10:42:09 2023 -0300

    Added thread option in commands
    Added error treatment in sfv downloading and login
    Moved progress print to DownloadManager class
    Saving dynamic checksum between retries
    WIP - Adding partial checksums so we don`t  have to recalculate
    Changed download speed to MB/s (instead of Mbps)

commit bfc068cd618bbff6f1e8784a2cc715e23dcc502b
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Fri Jan 20 19:11:14 2023 -0300

    Added thread download, and restart support

commit 7e1e6c3542c106f11086c50fe2f28f52d461a944
Author: Moroni Granja <m.oliveira.granja@avanade.com>
Date:   Fri Jan 20 12:51:39 2023 -0300

    WIP - Adding threaded Download